### PR TITLE
Replace obsoleted function

### DIFF
--- a/frog-menu.el
+++ b/frog-menu.el
@@ -510,7 +510,7 @@ Returns window of displayed buffer."
 
 
 (defun frog-menu--get-avy-candidates (&optional b w start end)
-  "Return candidates to be passed to `avy--process'.
+  "Return candidates to be passed to `avy-process'.
 
 B is the buffer of the candidates and defaults to the current
 one. W is the window where the candidates can be found and
@@ -601,7 +601,7 @@ ACTIONS is the argument of `frog-menu-read'."
                (avy-style 'at-full)
                (avy-action #'identity)
                (pos (with-selected-window window
-                      (avy--process
+                      (avy-process
                        candidates
                        (avy--style-fn avy-style)))))
           (cond ((number-or-marker-p pos)


### PR DESCRIPTION
This package is subject to the [Copyright Assignment](https://www.gnu.org/prep/maintain/html_node/Copyright-Papers.html)
policy of [GNU ELPA](https://elpa.gnu.org/packages/) packages.

If your changes are not
[significant](https://www.gnu.org/prep/maintain/html_node/Legally-Significant.html#Legally-Significant)
(below 15 lines) I can add your changes without assignment. If your contribution
is bigger than 15 lines and you don't want to assign you should still open a PR
and I will consider adding the changes myself.

The assignment is applicable for all projects related to Emacs. It basically
transfers copyright of your submitted changes to the FSF. That way they can
enforce [Copyleft](https://www.gnu.org/copyleft/).

The assignment process is very easy and can often be handled via email.

Please see [the request form](https://git.savannah.gnu.org/cgit/gnulib.git/tree/doc/Copyright/request-assign.future)
if you want to do the assignment (use Emacs for the name of the program you want to contribute to).

Confirm with `x` if applicable:

- [x] I have signed the copyright paperwork for contributing to GNU Emacs.

This fixes a following warning.

```
In frog-menu-query-with-avy:
frog-menu.el:604:24:Warning: ‘avy--process’ is an obsolete function (as of
    0.4.0); use ‘avy-process’ instead.
```
