### PR TITLE
(frog-menu-read): Handle alist collection with actions

### DIFF
--- a/frog-menu.el
+++ b/frog-menu.el
@@ -759,7 +759,7 @@ RETURN will be the returned value if KEY is pressed."
         (funcall cuhandler buf window)))
     (when (eq res 'frog-menu--complete)
       (setq res (frog-menu--complete prompt strings)))
-    (cond ((eq convf #'car)
+    (cond ((and (eq convf #'car) (stringp res))
            (cdr (assoc res collection)))
           (t res))))
 
@@ -767,7 +767,3 @@ RETURN will be the returned value if KEY is pressed."
 
 (provide 'frog-menu)
 ;;; frog-menu.el ends here
-
-
-
-


### PR DESCRIPTION
When passing the `collection' with an alist, together with some
`actions', selecting the action with a keystroke will return nil.

To reproduce:

    (frog-menu-read "Select: "
                    '(("alarm" . "this is an alarm")
                    ("book" . "this is a book"))
                    (list (list "F" "[find-file]" 'find-file)))

This package is subject to the [Copyright Assignment](https://www.gnu.org/prep/maintain/html_node/Copyright-Papers.html)
policy of [GNU ELPA](https://elpa.gnu.org/packages/) packages.

If your changes are not
[significant](https://www.gnu.org/prep/maintain/html_node/Legally-Significant.html#Legally-Significant)
(below 15 lines) I can add your changes without assignment. If your contribution
is bigger than 15 lines and you don't want to assign you should still open a PR
and I will consider adding the changes myself.

The assignment is applicable for all projects related to Emacs. It basically
transfers copyright of your submitted changes to the FSF. That way they can
enforce [Copyleft](https://www.gnu.org/copyleft/).

The assignment process is very easy and can often be handled via email.

Please see [the request form](https://git.savannah.gnu.org/cgit/gnulib.git/tree/doc/Copyright/request-assign.future)
if you want to do the assignment (use Emacs for the name of the program you want to contribute to).

Confirm with `x` if applicable:

- [ ] I have signed the copyright paperwork for contributing to GNU Emacs.
