### PR TITLE
Inherit the default background

### DIFF
--- a/frog-menu.el
+++ b/frog-menu.el
@@ -261,7 +261,7 @@ for this.")
   "Face used for menu action keybindings.")
 
 (defface frog-menu-posframe-background-face
-  '((t :background "old lace"))
+  '((t (:inherit default)))
   "Face used for the background color of the posframe.")
 
 (defvar frog-menu--buffer " *frog-menu-menu*"


### PR DESCRIPTION
- [ ] I have signed the copyright paperwork for contributing to GNU Emacs.

Is the decision to set the default background face to "old lace" intentional? It's currently causing issues on some darker themes, which forces users to customize it. I think leaving it as the default would be better.

Before:
![image](https://user-images.githubusercontent.com/1012677/231851993-24f58abb-fb7a-42ee-ad7f-8f8fc7e184d8.png)


After:
<img width="582" alt="image" src="https://user-images.githubusercontent.com/1012677/231851506-08e8aa10-f239-4ba8-ae3a-4af194a13a93.png">
